### PR TITLE
Development - assoc fail protection

### DIFF
--- a/app/Console/Commands/ReverseAssocCache.php
+++ b/app/Console/Commands/ReverseAssocCache.php
@@ -66,6 +66,9 @@ class ReverseAssocCache extends Command
                             continue;
 
                         foreach($values as $val) {
+                            if(!Record::isKIDPattern($val))
+                                continue;
+
                             $inserts[] = [
                                 'associated_kid' => $val,
                                 'associated_form_id' => explode('-',$val)[1],
@@ -100,6 +103,9 @@ class ReverseAssocCache extends Command
                             $vals = json_decode($subval->{$subFieldName},true);
 
                             foreach($vals as $val) {
+                                if(!Record::isKIDPattern($val))
+                                    continue;
+
                                 $inserts[] = [
                                     'associated_kid' => $val,
                                     'associated_form_id' => explode('-', $val)[1],
@@ -135,6 +141,9 @@ class ReverseAssocCache extends Command
                             $vals = json_decode($subval->{$subFieldName},true);
 
                             foreach($vals as $val) {
+                                if(!Record::isKIDPattern($val))
+                                    continue;
+                                
                                 $inserts[] = [
                                     'associated_kid' => $val,
                                     'associated_form_id' => explode('-', $val)[1],

--- a/app/Form.php
+++ b/app/Form.php
@@ -600,7 +600,11 @@ class Form extends Model {
                     if($aKids !== NULL) {
                         //We are going to recursively call this function for each associator in the record's associator field
                         //It's expensive, but that's the cost, use pagination
+                        $result[$column] = [];
                         foreach($aKids as $aKid) {
+                            if(!Record::isKIDPattern($aKid))
+                                continue;
+
                             $parts = explode('-',$aKid);
                             $aForm = $assocForms[$parts[1]];
                             $result[$column][$aKid] = $aForm->getRecordsForExport($assocFilters[$parts[1]],[$parts[2]],$con)[$aKid];
@@ -674,7 +678,11 @@ class Form extends Model {
                 else if(array_key_exists($column,$assocFields)) {
                     $aKids = json_decode($data,true);
                     if($aKids !== NULL && !empty($assocForms)) {
+                        $result[$column] = [];
                         foreach($aKids as $aKid) {
+                            if(!Record::isKIDPattern($aKid))
+                                continue;
+
                             $parts = explode('-',$aKid);
                             $aForm = $assocForms[$parts[1]];
                             $result[$column][$aKid] = $aForm->getRecordsForExport($assocFilters[$parts[1]],[$parts[2]],$con)[$aKid];

--- a/app/KoraFields/AssociatorField.php
+++ b/app/KoraFields/AssociatorField.php
@@ -387,6 +387,9 @@ class AssociatorField extends BaseField {
      * @return string - Html structure of the preview field's value
      */
     public static function getPreviewValues($field,$kid) {
+        if(!Record::isKIDPattern($kid))
+            return '';
+
         //individual kid elements
         $recParts = explode('-',$kid);
         $pid = $recParts[0];

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ educational value of the objects.
        RewriteBase /digitalRepo/kora/public
        
     b) Configure the `php_value` rules in the newly created `.htaccess` if the installation supports variable 
-       overwriting in htaccess (i.e. if you plan on uploading larger files).
+       overwriting in htaccess (i.e. if you plan on uploading larger files and/or importing larger record sets).
 
 3) Create `.env` from the example in `kora`:
 

--- a/resources/views/partials/records/input/associator.blade.php
+++ b/resources/views/partials/records/input/associator.blade.php
@@ -4,8 +4,10 @@
     if($editRecord && !is_null($record->{$flid})) {
         $selected = array();
         foreach(json_decode($record->{$flid},true) as $kid) {
-            $value[$kid] = $kid;
-            $selected[] = $kid;
+            if(\App\Record::isKIDPattern($kid)) {
+                $value[$kid] = $kid;
+                $selected[] = $kid;
+            }
         }
     }
 @endphp


### PR DESCRIPTION
If multi importer fails, some associators have kidConnections left in them. This protects against some errors that happened