### PR TITLE
Fixed issue with project edit routes

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -98,7 +98,7 @@ function getDashboardProjectBlockLink($block, $link_type) {
           return [
             'tooltip' => 'Edit Project',
             'icon-class' => 'icon-edit-little',
-            'href' => action('ProjectController@edit', ['pid'=>$options['pid']]),
+            'href' => action('ProjectController@edit', ['projects'=>$options['pid']]),
 			'type' => 'edit'
           ];
           break;

--- a/resources/views/partials/menu/project.blade.php
+++ b/resources/views/partials/menu/project.blade.php
@@ -61,7 +61,7 @@
       <li class="spacer"></li>
 
       <li class="link first">
-        <a href="{{ action('ProjectController@edit', ['pid'=>$pid]) }}">Edit Project Information</a>
+        <a href="{{ action('ProjectController@edit', ['projects'=>$pid]) }}">Edit Project Information</a>
       </li>
 
       <li class="link">

--- a/resources/views/partials/projects/index/project.blade.php
+++ b/resources/views/partials/projects/index/project.blade.php
@@ -89,7 +89,7 @@
 
     @if (!$archived)
       <div class="footer">
-        <a class="quick-action underline-middle-hover" href="{{ action('ProjectController@edit',['pid' => $project->id]) }}">
+        <a class="quick-action underline-middle-hover" href="{{ action('ProjectController@edit',['projects' => $project->id]) }}">
           <i class="icon icon-edit-little"></i>
           <span>Edit Project Info</span>
         </a>

--- a/resources/views/partials/sideMenu/project.blade.php
+++ b/resources/views/partials/sideMenu/project.blade.php
@@ -62,7 +62,7 @@
       <li class="spacer"></li>
 
       <li class="content-link content-link-js" data-page="project-edit">
-        <a href="{{ action('ProjectController@edit', ['pid'=>$pid]) }}">Edit Project Information</a>
+        <a href="{{ action('ProjectController@edit', ['projects'=>$pid]) }}">Edit Project Information</a>
       </li>
 
       <li class="content-link content-link-js" data-page="project-permissions">

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -18,7 +18,7 @@
       <div class="inner-wrap center">
         <h1 class="title">
           <i class="icon icon-project"></i>
-          <a href="{{ action('ProjectController@edit',['pid' => $project->id]) }}" class="head-button tooltip" tooltip="Edit Project">
+          <a href="{{ action('ProjectController@edit',['projects' => $project->id]) }}" class="head-button tooltip" tooltip="Edit Project">
             <i class="icon icon-edit right"></i>
           </a>
           <span>{{ $project->name }}</span>


### PR DESCRIPTION
# Pull Request Template

## Description

With the laravel updates we did, the default route variables for Resources had changed. Projects are the only model that used the default routes. Edit was one of those that we were using the wrong variable, so I updated it for every link.

Fixes #691 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested edit links on Project cards, view Project page, and in the 2 menus.

**Test Configuration**:
* kora version: 3.0.0
* OS: Chrome

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
