### PR TITLE
Fix for new combo list fields. Sub field names are now properly trimmed

### DIFF
--- a/app/Http/Controllers/FieldController.php
+++ b/app/Http/Controllers/FieldController.php
@@ -86,7 +86,7 @@ class FieldController extends Controller {
         if($request->type == Form::_COMBO_LIST) {
             foreach(['one' => 1, 'two' => 2] as $seq => $num) {
                 $slug = slugFormat(
-                    $request->{'cfname' . $num},
+                    trim($request->{'cfname' . $num}),
                     $form->project_id,
                     $form->id
                 );
@@ -96,7 +96,7 @@ class FieldController extends Controller {
                 ];
                 $field[$seq] = [
                     'type' => $request->{'type' . $seq},
-                    'name' => $request->{'cfname' . $num},
+                    'name' => trim($request->{'cfname' . $num}),
                     'flid' => $slug,
                     'default' => null
                 ];

--- a/app/Http/Controllers/FieldController.php
+++ b/app/Http/Controllers/FieldController.php
@@ -207,11 +207,11 @@ class FieldController extends Controller {
 
             foreach(['one' => 1, 'two' => 2] as $seq => $num) {
                 $cFlid = slugFormat($field[$seq]['name'], $form->project_id, $form->id);
-                $cNewFlid = slugFormat($request->{'cfname' . $num}, $form->project_id, $form->id);
+                $cNewFlid = slugFormat(trim($request->{'cfname' . $num}), $form->project_id, $form->id);
                 if($cFlid != $cNewFlid) {
                     $form->updateSubField($flid, $cFlid, $cNewFlid);
                     $field[$seq]['flid'] = $cNewFlid;
-                    $field[$seq]['name'] = $request->{'cfname' . $num};
+                    $field[$seq]['name'] = trim($request->{'cfname' . $num});
                 } else {
                     $form->updateSubField($flid, $cFlid);
                 }


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed an issue where whitespace was allowed in combo list sub field names. These names are now properly trimmed on create and edit field.

Fixes #693 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested by creating a new combo field with spaces after each sub field name. Also tried the same in edit field. Both cases removed the whitespace properly.

**Test Configuration**:
* kora version: 3.0.0
* Browser: Brave
* OS: MacOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
