### PR TITLE
Fixed url redirects for after login

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -72,7 +72,8 @@ class LoginController extends Controller
                 if(Hash::check($user->token, $hashUser->gitlab_token)) {
                     Auth::login($hashUser);
 
-                    return redirect('/home');
+                    //This handles intended url redirects after login
+                    return redirect()->intended($this->redirectPath());
                 }
             }
 

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -44,12 +44,20 @@ class Authenticate {
 			} else {
                 //Replicating guest function to force https in production
                 //This fixes the issue where user wasn't bounced to intended url after login in https
-                $secure = false;
-                if(config('app.env') === 'production')
-                    $secure = true;
-                Session::put('url.intended', redirect()->getUrlGenerator()->current());
+                $request = redirect()->getUrlGenerator()->getRequest();
 
-                return redirect()->to('/', 302, [], $secure);
+                $intended = $request->method() === 'GET' && $request->route() && ! $request->expectsJson()
+                    ? redirect()->getUrlGenerator()->full()
+                    : redirect()->getUrlGenerator()->previous();
+
+                //Force https
+                $intended = str_replace('http://','https://',$intended);
+
+                if($intended) {
+                    redirect()->setIntendedUrl($intended);
+                }
+
+                return redirect()->to('/home', 302, [], true);
 			}
 		}
 


### PR DESCRIPTION
## Description

Redirecting to the intended link after login now works. Had to update the function we overwrite from the Redirector vendor class to be up to date. This fixed user/password login redirects. Had to add an extra rule to OAuth logins to make sure they also used the redirect.

Fixes #703 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Used link to random kora form. Made sure I was logged out. Went to link in browser. Logged in with user/password. Redirect was successful. Repeated process for gitlab OAuth.

**Test Configuration**:
* kora version: 3.0.0
* Browser: Brave
* OS: MacOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
