### PR TITLE
Fixed AZ sorting in user management

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -47,12 +47,12 @@ class AdminController extends Controller {
         $userNameSort = [];
 
         foreach($users as $user) {
-            $userNameSort[$user->preferences['first_name']] = $user;
+            $userNameSort[$user->preferences['first_name'].'_'.$user->username] = $user;
         }
 
         ksort($userNameSort);
         $usersAz = $userNameSort;
-        ksort($userNameSort,SORT_DESC);
+        krsort($userNameSort);
         $usersZa = $userNameSort;
         $usersNto = User::latest()->get();
         $usersOtn = User::orderBy('created_at')->get();


### PR DESCRIPTION
# Pull Request Template

## Description

Users with the same first name were not all appearing together in the user management page when sorting by A-Z or Z-A. Along with that, Z-A was also sorting the wrong direction. Both of the issues are solved by this.

Fixes #725 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* kora version: kora 3.0.0
* Browser: Safari
* OS: MacOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
