### PR TITLE
Fixed legacy KID searching within kora

### DIFF
--- a/app/Http/Controllers/ProjectSearchController.php
+++ b/app/Http/Controllers/ProjectSearchController.php
@@ -89,7 +89,6 @@ class ProjectSearchController extends Controller {
             //INITIAL PAGE VISIT
             $records = [];
             $total = 0;
-            $ignored = [];
             $initial = true;
             $page = 1;
             $pageCount = 10;
@@ -102,7 +101,7 @@ class ProjectSearchController extends Controller {
             $forms[$f->id] = $f->name;
         }
 
-        return view('projectSearch.results', compact("project", "forms", "records", "total", "ignored", "initial", "page", "pageCount"));
+        return view('projectSearch.results', compact("project", "forms", "records", "total", "initial", "page", "pageCount"));
     }
 
     private function imitateMerge(&$array1, &$array2) {
@@ -173,7 +172,6 @@ class ProjectSearchController extends Controller {
             //INITIAL PAGE VISIT
             $records = [];
             $total = 0;
-            $ignored = [];
             $page = 1;
             $pageCount = 10;
         }
@@ -221,7 +219,7 @@ class ProjectSearchController extends Controller {
         }
 
         return view('globalSearch.results', compact(
-            "projects", "records", "total", "ignored",
+            "projects", "records", "total",
             'projectArray', 'formArray', 'fieldArray', "page", "pageCount"
         ));
     }

--- a/app/Http/Controllers/RecordController.php
+++ b/app/Http/Controllers/RecordController.php
@@ -746,11 +746,15 @@ class RecordController extends Controller {
         if(!Record::isLegacyKIDPattern($kid))
             return null;
 
-        $parts = explode('-',$kid);
-        $recordMod = new Record(array(),$parts[1]);
-        $record = $recordMod->newQuery()->where('legacy_kid', '=', $kid)->first();
+        $forms = Form::all();
+        foreach($forms as $form) {
+            $recordMod = new Record(array(),$form->id);
+            $record = $recordMod->newQuery()->where('legacy_kid', '=', $kid)->first();
+            if(!is_null($record))
+                return $record;
+        }
 
-        return $record;
+        return null;
     }
 
     /**


### PR DESCRIPTION
# Fixed legacy KID searching within kora

## Description

We can now use both global search, and the KID type on form and project search pages, to look for a record by legacy KID
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by adding a fake legacy KID to a record and using that legacy KID on every type of search.

**Test Configuration**:
* kora version: 3.0.0
* Browser: Safari
* OS: MacOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
