### PR TITLE
suggest comment change

### DIFF
--- a/public/.htaccess.example
+++ b/public/.htaccess.example
@@ -4,7 +4,7 @@
     </IfModule>
 
     RewriteEngine On
-    #RewriteBase #add base url ex: www.website.com[/this part is your base url for this file up to "public"]
+    #RewriteBase #add base url ex: www.website.com[/this part is your base url, the url subdirectory where you want your installation to be accessible from]
 	#RewriteBase /your_base_url
 
     # Handle Authorization Header


### PR DESCRIPTION
This proposed change is to better explain how a user identifies what their `/your_base_url` is. In our installation documentation, it is explained that this is pointed via symlink to "kora/public." In this file, But I found this comment quite confusing given my lack of prior knowledge, so this is an alternative that I hope alleviates that confusion for others.

I get this proposed comment may not be ideal either, so feel free to reject this if an alternative would work better.

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

This is a comment; it will not affect anything in Kora's programming.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
