### PR TITLE
Fixed for values not dissapearing during import if intended record no…

### DIFF
--- a/app/Http/Controllers/ImportMultiFormController.php
+++ b/app/Http/Controllers/ImportMultiFormController.php
@@ -446,11 +446,11 @@ class ImportMultiFormController extends Controller {
     public function connectRecords($pid, Request $request) {
 	    ini_set('max_execution_time',0);
         $fids = $request->fids;
-        
+
         $kids = json_decode($request->kids,true);
 		$connections = json_decode($request->connections,true);
         $connErrors = [];
-        
+
         foreach($fids as $fid) {
             $form = FormController::getForm($fid);
             $recModel = new Record(array(),$fid);
@@ -462,7 +462,7 @@ class ImportMultiFormController extends Controller {
                 if($field['type'] == Form::_ASSOCIATOR)
                     $assocField[] = $flid;
             }
-            
+
             foreach($records as $record) {
 	        	foreach($assocField as $flid) {
 	                $assoc = json_decode($record->{$flid});
@@ -476,11 +476,17 @@ class ImportMultiFormController extends Controller {
                                 $newAssoc[] = $connections[$val];
                             } else if(Record::isKIDPattern($val)) { //Normal KID value
                                 $newAssoc[] = $val;
-                            } else //Connection not found
+                            } else { //Connection not found
+    							$update = true;
                                 $connErrors[] = ['connection' => $val, 'record' => $record->kid, 'field' => $fieldsArray[$flid]['name']];
-	                    }
-	                    if($update)
-	                    	$record->{$flid} = json_encode($newAssoc);
+                            }
+                        }
+                        if($update) {
+                            if(empty($newAssoc))
+                        	    $record->{$flid} = null;
+                            else
+                                $record->{$flid} = json_encode($newAssoc);
+                        }
 	                }
                 }
                 $record->save();


### PR DESCRIPTION
…t found

# Pull Request Template

## Description

During an import, if an association connection fails, we properly report it, but we do not remove that connection value from the record data. The connection value is now properly removed from the record.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* kora version: 3.0.0
* Browser: Safari
* OS: MacOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
