### PR TITLE
Record Import Chrome Fix

### DIFF
--- a/public/assets/javascripts/records/import.js
+++ b/public/assets/javascripts/records/import.js
@@ -119,10 +119,10 @@ Kora.Records.Import = function () {
                             var connections = {};
 
                             //Initialize throttler to prevent
-                            var throttle = throttledQueue(100, 5000);
+                            var throttle = throttledQueue(200, 5000);
 
                             //foreach record in the dataset
-                            for (var import_id in importRecs) {
+                            for(var import_id in importRecs) {
                                 throttle({ "import_id": import_id, "type": importType, "record": importRecs[import_id], "table": table }, function(importData) {
                                     //ajax to store record
                                     $.ajax({
@@ -139,7 +139,7 @@ Kora.Records.Import = function () {
                                         success: function (data) {
                                             //building connections
                                             kids.push(data['kid']);
-                                            if (data['kidConnection'].length != 0) connections[data['kidConnection']] = data['kid'];
+                                            if(data['kidConnection'].length != 0) connections[data['kidConnection']] = data['kid'];
 
                                             succ++;
                                             progressText.text(succ + ' of ' + total + ' Records Submitted');
@@ -147,14 +147,14 @@ Kora.Records.Import = function () {
                                             done++;
                                             //update progress bar
                                             percent = (done / total) * 100;
-                                            if (percent < 7)
+                                            if(percent < 7)
                                                 percent = 7;
                                             progressFill.attr('style', 'width:' + percent + '%');
                                             progressText.text(succ + ' of ' + total + ' Records Submitted');
 
-                                            if (done == total) {
+                                            if(done == total) {
                                                 $('.progress-text-js').html('Connecting cross-Form associations. One moment...');
-                                                if (connections && kids) {
+                                                if(connections && kids) {
                                                     $.ajax({
                                                         url: connectRecordsUrl,
                                                         type: 'POST',
@@ -171,7 +171,7 @@ Kora.Records.Import = function () {
                                                     completeImport(succ, total, importData["type"]);
                                             }
                                         },
-                                        error: function (data) {
+                                        error: function(data) {
                                             $.ajax({
                                                 url: saveFailedUrl,
                                                 type: 'POST',
@@ -179,7 +179,7 @@ Kora.Records.Import = function () {
                                                     "_token": CSRFToken,
                                                     "failure": JSON.stringify([importData["import_id"], importData["record"], data]),
                                                     "type": importData["type"]
-                                                }, success: function (data) {
+                                                }, success: function(data) {
                                                     //
                                                 }
                                             });
@@ -187,14 +187,14 @@ Kora.Records.Import = function () {
                                             done++;
                                             //update progress bar
                                             percent = (done / total) * 100;
-                                            if (percent < 7)
+                                            if(percent < 7)
                                                 percent = 7;
                                             progressFill.attr('style', 'width:' + percent + '%');
                                             progressText.text(succ + ' of ' + total + ' Records Submitted');
 
-                                            if (done == total) {
+                                            if(done == total) {
                                                 $('.progress-text-js').html('Connecting cross-Form associations. One moment...');
-                                                if (connections && kids) {
+                                                if(connections && kids) {
                                                     $.ajax({
                                                         url: connectRecordsUrl,
                                                         type: 'POST',
@@ -202,7 +202,7 @@ Kora.Records.Import = function () {
                                                             "_token": CSRFToken,
                                                             "connections": JSON.stringify(connections),
                                                             "kids": JSON.stringify(kids)
-                                                        }, success: function (data) {
+                                                        }, success: function(data) {
                                                             failedConnections = JSON.parse(data);
                                                             completeImport(succ, total, importData["type"]);
                                                         }

--- a/public/assets/javascripts/vendor/throttled-queue/throttled-queue.js
+++ b/public/assets/javascripts/vendor/throttled-queue/throttled-queue.js
@@ -41,6 +41,7 @@
         var queue = [];
         var lastCalled = Date.now();
         var timeout;
+        var activeRecords = 0;
 
         /**
          * Gets called at a set interval to remove items from the queue.
@@ -55,9 +56,17 @@
             /**
              * Adjust the timer if it was called too early.
              */
-            if (now < threshold) {
+            if(now < threshold) {
                 clearTimeout(timeout);
                 timeout = setTimeout(dequeue, threshold - now);
+                return;
+            }
+
+            /**
+             * If the queue is backedup, wait another cycle.
+             */
+            if(activeRecords-done > 500) {
+                timeout = setTimeout(dequeue, interval);
                 return;
             }
 
@@ -65,6 +74,8 @@
             for(var x = 0; x < callbacks.length; x++) {
                 callbacks[x][0](callbacks[x][1]); //Now pass the temp ID into the callback (See enqueue below)
             }
+
+            activeRecords += callbacks.length;
 
             lastCalled = Date.now();
             if (queue.length) {


### PR DESCRIPTION
# Pull Request Template

## Description

Modified the throttle queue system for record import to limit the amount of active Ajax connections. This fixes a bug for importing large record sets on chrome, where too many requests open would cause chrome to run out of resources.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran a test of 5000 records imported into a kora form. I set an arbitrary wait time of 1 second for each record request so that the speed of records being ingested would be slower than the rate at which records were added to the queue.

**Test Configuration**:
* kora version: 3.0.0
* Browser: Microsoft Edge
* OS: MacOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
