### PR TITLE
Fix for file type fields reading the database

### DIFF
--- a/app/KoraFields/FileTypeField.php
+++ b/app/KoraFields/FileTypeField.php
@@ -576,18 +576,15 @@ abstract class FileTypeField extends BaseField {
         }
 
         //Prep comparing of allowed number files, vs files already in tmp folder
-        $maxFileNum = !is_null($field['options']['MaxFiles']) ? $field['options']['MaxFiles'] : 0;
+        $maxFileNum = (!is_null($field['options']['MaxFiles']) && $field['options']['MaxFiles']!="") ? $field['options']['MaxFiles'] : 0;
         $fileNumRequest = sizeof($_FILES['file'.$flid]['name']);
         if(glob($dir.'/*.*') != false)
             $fileNumDisk = count(glob($dir.'/*.*'));
         else
             $fileNumDisk = 0;
-
-        $maxFieldSize = $field['options']['FieldSize'];
-    		if (trim($maxFieldSize) === '') {
-    			$maxFieldSize = '0';
-    		}
-    		$maxFieldSize = $maxFieldSize * 1024;
+        
+        $maxFieldSize = (!is_null($field['options']['FieldSize']) && $field['options']['FieldSize']!="") ? $field['options']['FieldSize'] : 0;
+        $maxFieldSize = $maxFieldSize * 1024;
 
         $fileSizeRequest = 0;
         foreach($_FILES['file'.$flid]['size'] as $size) {


### PR DESCRIPTION
# Pull Request Template

## Description

Validates the options of Max Field Size and Max File Limit for File Field types. If the JSON for those values someone was set to null or empty, we default it to zero.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* kora version: 3.0.0
* Browser: Edge
* OS: MacOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
