### PR TITLE
Query Optimize for old query calls

### DIFF
--- a/app/Http/Controllers/RestfulBetaController.php
+++ b/app/Http/Controllers/RestfulBetaController.php
@@ -207,7 +207,10 @@ class RestfulBetaController extends Controller {
             }
 
             //parse the query
-            if(!isset($f->query)) {
+            //note: if there is a query, we check to make sure the search isn't just asking for all records in the
+            //      opposite sense (i.e. give me the opposite of no records). If we don't check this, the final MYSQL
+            //      query will have every record id listed in it for no reason.
+            if(!isset($f->query) || (sizeof($f->query)==1 && $f->query[0]->search=="kid" && empty($f->query[0]->kids) && $f->query[0]->not)) {
                 //return all records
                 if($apiFormat==self::XML)
                     $records = $form->getRecordsForExportXML($filters);

--- a/app/Http/Controllers/RestfulController.php
+++ b/app/Http/Controllers/RestfulController.php
@@ -379,7 +379,10 @@ class RestfulController extends Controller {
             }
 
             //parse the query
-            if(!isset($f->queries)) {
+            //note: if there is a query, we check to make sure the search isn't just asking for all records in the
+            //      opposite sense (i.e. give me the opposite of no records). If we don't check this, the final MYSQL
+            //      query will have every record id listed in it for no reason.
+            if(!isset($f->queries) || (sizeof($f->queries)==1 && $f->queries[0]->search=="kid" && empty($f->queries[0]->kids) && $f->queries[0]->not)) {
                 //return all records
                 if($apiFormat==self::XML)
                     $records = $form->getRecordsForExportXML($filters);


### PR DESCRIPTION
# Pull Request Template

## Description

A lot of sites using Kora 2 previously asked for all records where KID is not blank. This is the reverse of asking for all records, and led to the API for kora 3 building a mysql query roughly like `select * from records where id in (1,2,3,4,5,6,7,8.....)` in order to get every record.

This fix will check if that old query (modernized as `{"search":"kid","kids":[],"not": true}` in the API), and remove it is the only query. This will lead to the API providing every record with a more normalized query like `select * from records`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:
* kora version: 3.0
* Browser: Edge
* OS: MacOS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
